### PR TITLE
Improve what could be improved

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN apk add --update py-pip curl unzip                               && \
     cd plancton-master                                               && \
     pip install -e .                                                 && \
     apk del unzip                                                    && \
-    rm -Rf /var/cache/apk/*                                          
+    rm -f master.zip                                                 && \
+    rm -Rf /var/cache/apk/*
 
 COPY entrypoint.sh /tmp/entrypoint.sh
 

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ docker run --rm -it -v/var/run/docker.sock:/var/run/docker.sock --name plancton-
 Run detached:
 
 ```
-docker run --rm -d -v/var/run/docker.sock:/var/run/docker.sock --name plancton-nodaemon plancton
+docker run -d -v/var/run/docker.sock:/var/run/docker.sock --name plancton-nodaemon plancton
 ```
 
 
 ## Variables
 
-_You can provide such variables to docker via the `-e` switch._
+_You can provide such variables to Docker via the `-e` switch._
 
 * `PLANCTON_CONF_URL`: URL pointing to the Plancton configuration file.
   Plancton will not start if the configuration is not found.

--- a/README.md
+++ b/README.md
@@ -1,23 +1,46 @@
-# Run Plancton inside a Docker contaiener
-Container image containing the [Plancton](https://github.com/mconcas/plancton) daemon.
-It is based on `alpine` Linux.
+Run Plancton from a Docker contaiener
+=====================================
+
+Container image containing the [Plancton](https://github.com/mconcas/plancton)
+daemon.  It is based on `alpine` Linux.
+
 It uses a forwarded Docker socket exposed in `/var/run/docker.sock`.
 
-The `entrypoint.sh` script periodically downolads configuration pointed in `URL` and puts it in `CONFDIR`.
-It runs in foreground mode inside the container afterwards. 
+The `entrypoint.sh` script periodically downolads configuration pointed in
+`URL` and puts it in `CONFDIR`.  It runs in foreground mode inside the
+container afterwards.
+
 
 ## Build
+
 ```
 docker build -t plancton .
 ```
 
+
 ## Run
-Run in interactively
+
+Run in interactively:
+
 ```
 docker run --rm -it -v/var/run/docker.sock:/var/run/docker.sock --name plancton-nodaemon plancton
 ```
 
-Run detached
+Run detached:
+
 ```
 docker run --rm -d -v/var/run/docker.sock:/var/run/docker.sock --name plancton-nodaemon plancton
 ```
+
+
+## Variables
+
+_You can provide such variables to docker via the `-e` switch._
+
+* `PLANCTON_CONF_URL`: URL pointing to the Plancton configuration file.
+  Plancton will not start if the configuration is not found.
+* `PLANCTON_CONF_UPDATE`: How frequently, in seconds, the configuration is
+  updated. Failures will not destroy the current configuration and are not
+  fatal.
+* `PLANCTON_CONF_NOSSLVERIFY`: Set it to `1` to skip SSL certificate
+  verification when downloading the configuration file.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,10 +1,14 @@
-#! /bin/sh -e
-
-CONFDIR=/etc/plancton
-URL="https://raw.githubusercontent.com/mconcas/plancton-conf/dryrun/config.yaml"
-SLEEP=30
-
-mkdir -p $CONFDIR
-( while [[ 1 ]]; do cd $CONFDIR && curl -LOk $URL || true; sleep $SLEEP; done; ) &
-
+#!/bin/sh -e
+set -o pipefail
+PLANCTON_CONF_URL=${PLANCTON_CONF_URL:-"https://raw.githubusercontent.com/mconcas/plancton-conf/dryrun/config.yaml"}
+PLANCTON_CONF_UPDATE=${PLANCTON_CONF_UPDATE:-600}
+mkdir -p /etc/plancton && [ -d /etc/plancton ]
+I=0
+while [ $I -lt 2 ]; do
+  curl -sSLf ${PLANCTON_CONF_NOSSLVERIFY:+-k} -o /etc/plancton/config.yaml "$PLANCTON_CONF_URL" && break || true
+  sleep $I
+  I=$(( I + 1 ))
+done
+[ -e /etc/plancton/config.yaml ] || { echo "Could not download configuration from $PLANCTON_CONF_URL, aborting"; exit 1; }
+( while true; do curl -sSLf ${PLANCTON_CONF_NOSSLVERIFY:+-k} -o /etc/plancton/config.yaml "$PLANCTON_CONF_URL" || true; sleep "$PLANCTON_CONF_UPDATE"; done; )&
 planctonctl nodaemon


### PR DESCRIPTION
* Remove `master.zip` after installing Plancton
* Improve documentation
* Make things configurable via `docker -e`
* Prevent `curl` from destroying configuration in case of temporary failures
* Do not assume the configuration file name to be `config.yaml`
* Do not start Plancton if configuration file cannot be downloaded at least once
* Remove non-POSIX syntax
* Do not skip SSL verification by default (but make it optional)